### PR TITLE
Keep the label of "upload your own" after click.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import keyboards from "./src/keyboards.json";
 import { Elm } from "./src/App.elm";
 import { crc16 } from "crc";
 
+const uploadLabel = "upload your own";
 const app = Elm.App.init({
   node: document.getElementById("main"),
   flags: {
@@ -19,6 +20,7 @@ const app = Elm.App.init({
       "ble_micro_pro_bootloader_1_0_2_rc",
     ],
     applications: ["ble_micro_pro_vial_1_1_2", "ble_micro_pro_vial_1_0_8"],
+    uploadLabel: uploadLabel,
   },
 });
 
@@ -135,8 +137,8 @@ app.ports.updateFirmware.subscribe(async (command) => {
 app.ports.updateConfig.subscribe(async (setup) => {
   console.log(setup);
 
-  if (!setup.keyboard) {
-    loadUserFile(".bin", async (fileBuffer) => {
+  if (!setup.keyboard || setup.keyboard == uploadLabel) {
+      loadUserFile(".bin", async (fileBuffer) => {
       if (
         fileBuffer[0] != 0xae ||
         fileBuffer[1] != 0xfa ||

--- a/src/App.elm
+++ b/src/App.elm
@@ -116,6 +116,7 @@ type alias Flag =
     , keyboards : List Keyboard
     , bootloaders : List String
     , applications : List String
+    , uploadLabel : String  -- "upload your own" in the selection list
     }
 
 
@@ -166,7 +167,7 @@ type alias PairList =
 
 flagDecoder : Decoder Flag
 flagDecoder =
-    D.map5 Flag
+    D.map6 Flag
         (field "revision" D.string)
         (field "webSerialEnabled" bool)
         (field "keyboards"
@@ -184,6 +185,7 @@ flagDecoder =
         )
         (field "bootloaders" (D.list string))
         (field "applications" (D.list string))
+        (field "uploadLabel" string)
 
 
 updateProgressEncode : E.Value -> UpdateProgress
@@ -241,7 +243,7 @@ init flags url key =
                     flag
 
                 Err _ ->
-                    Flag "" False [] [] []
+                    Flag "" False [] [] [] "(uploadLabel)"
       , needsHelp = False
       , setupRequirement =
             { keyboard = Keyboard "" [] [] "" False False
@@ -714,7 +716,7 @@ updateKeyboard model name =
     let
         keyboard =
             Maybe.withDefault
-                (Keyboard "" [] [] "" False False)
+                (Keyboard name [] [] "" False False)
                 (List.head
                     (List.filter (\n -> n.name == name)
                         model.appInfo.keyboards
@@ -1044,7 +1046,7 @@ viewEditConfig model =
                  else
                     model.filterText
                 )
-                ([ "", "upload your own" ]
+                ([ "", model.appInfo.uploadLabel ]
                     ++ List.map
                         (\k -> k.name)
                         model.appInfo.keyboards
@@ -1181,7 +1183,7 @@ viewEditKeymap model =
                  else
                     model.filterText
                 )
-                ([ "", "upload your own" ]
+                ([ "", model.appInfo.uploadLabel ]
                     ++ List.filterMap
                         (\k ->
                             if List.length k.keymap > 0 then


### PR DESCRIPTION
Hi, I'd like to address an issue of keyboard selection.
Would you merge my PR?

# current behavior without this commit

"upload your own" is an item in the keyboard selection list.
When it is clicked, the selected item is removed and an empty page is shown.

![image](https://github.com/sekigon-gonnoc/BLE-Micro-Pro-WebConfigurator/assets/11634377/5bfae8c3-9cd4-43cd-b79d-9467672d81bf)

# new behavior with this commit

When "upload your own" is clicked, the select item is changed and options are shown.

![image](https://github.com/sekigon-gonnoc/BLE-Micro-Pro-WebConfigurator/assets/11634377/4dad3f64-9313-4f1b-ac68-d9781ab24f93)
